### PR TITLE
Upgrade ciris, cats-core, cats-effect, awssdk, scala and sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ name := "ciris-aws-secretsmanager"
 organization := "com.ovoenergy"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
-scalaVersion := "3.1.0"
-crossScalaVersions := Seq(scalaVersion.value, "2.13.5", "2.12.13")
+scalaVersion := "3.2.2"
+crossScalaVersions := Seq(scalaVersion.value, "2.13.10", "2.12.17")
 releaseCrossBuild := true
 
 libraryDependencies ++= Seq(
-  "is.cir" %% "ciris" % "2.2.1",
-  "org.typelevel" %% "cats-core" % "2.6.1",
-  "org.typelevel" %% "cats-effect" % "3.2.9",
-  "software.amazon.awssdk" % "secretsmanager" % "2.15.58",
+  "is.cir" %% "ciris" % "3.1.0",
+  "org.typelevel" %% "cats-core" % "2.9.0",
+  "org.typelevel" %% "cats-effect" % "3.4.8",
+  "software.amazon.awssdk" % "secretsmanager" % "2.20.32",
   "org.typelevel" %% "munit-cats-effect-3" % "1.0.6" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,3 +48,5 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
+
+Compile / doc / sources := Nil

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")


### PR DESCRIPTION
Initially I just wanted to upgrade ciris from 2.x to 3.x, but ended up upgrading the other dependencies as well. This might require a minor or major release because ciris 3.x is incompatible with 2.x.